### PR TITLE
require ath_methods in challenges when RS does not support ath

### DIFF
--- a/draft-skokan-oauth-additional-hashes.md
+++ b/draft-skokan-oauth-additional-hashes.md
@@ -353,13 +353,11 @@ Resource Server supports, analogous to the `algs` parameter defined
 in {{Section 7.1 of RFC9449}}. A Resource Server that does not
 support `ath` MUST include the `ath_methods` parameter in any
 `WWW-Authenticate: DPoP` challenge it issues. When `ath_methods`
-is absent and the Client has not obtained the Resource Server's
+is absent: if the Client is aware of the Resource Server's
 `dpop_access_token_hash_methods_supported` metadata, the Client
-MUST use `ath`. When `ath_methods` is absent but the Client has
-previously obtained the Resource Server's metadata, the Client
-MUST use a method from
-`dpop_access_token_hash_methods_supported`. When `ath_methods` is
-present, the Client MUST use one of the listed methods.
+MUST use a method from that set; otherwise, the Client MUST use
+`ath`. When `ath_methods` is present, the Client MUST use one of
+the listed methods.
 Additionally, Resource Server metadata for the supported access
 token hash methods is defined in {{dpop-rs-metadata}}.
 

--- a/draft-skokan-oauth-additional-hashes.md
+++ b/draft-skokan-oauth-additional-hashes.md
@@ -350,11 +350,18 @@ methods by including the `ath_methods` parameter in the
 `WWW-Authenticate: DPoP` challenge. The value of `ath_methods` is a
 space-delimited list of access token hash claim names that the
 Resource Server supports, analogous to the `algs` parameter defined
-in {{Section 7.1 of RFC9449}}. When `ath_methods` is absent, the
-Client MUST use `ath`. When `ath_methods` is present, the Client
-MUST use one of the listed methods. Additionally, Resource Server
-metadata for the supported access token hash methods is defined in
-{{dpop-rs-metadata}}.
+in {{Section 7.1 of RFC9449}}. A Resource Server that does not
+support `ath` MUST include the `ath_methods` parameter in any
+`WWW-Authenticate: DPoP` challenge it issues. When `ath_methods`
+is absent and the Client has not obtained the Resource Server's
+`dpop_access_token_hash_methods_supported` metadata, the Client
+MUST use `ath`. When `ath_methods` is absent but the Client has
+previously obtained the Resource Server's metadata, the Client
+MUST use a method from
+`dpop_access_token_hash_methods_supported`. When `ath_methods` is
+present, the Client MUST use one of the listed methods.
+Additionally, Resource Server metadata for the supported access
+token hash methods is defined in {{dpop-rs-metadata}}.
 
 The following is a non-normative example of an HTTP response
 signalling the client to use `ath#S512`:


### PR DESCRIPTION
Clarify ath_methods behavior when a Resource Server supports only ath#S512. A RS that does not support the default ath claim must now include ath_methods in WWW-Authenticate challenges. Clients may also use previously obtained RS metadata to determine the correct method when ath_methods is absent from the challenge.

Closes #5

cc @MichaelFraser99